### PR TITLE
support new keyword spec format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 npm-debug.log
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -11,12 +11,38 @@ Creates a new parser.
 The `keywordspec` parameter is optional, with the default being:
 ```javascript
 {
-  _: [0],
-  gettext: [0],
-  ngettext: [0, 1]
+    _: {
+        msgid: 0
+    },
+    gettext: {
+        msgid: 0
+    },
+    dgettext: {
+        msgid: 1
+    },
+    dcgettext: {
+        msgid: 1
+    },
+    ngettext: {
+        msgid: 0,
+        msgid_plural: 1
+    },
+    dngettext: {
+        msgid: 1,
+        msgid_plural: 2
+    },
+    pgettext: {
+        msgctxt: 0,
+        msgid: 1
+    },
+    dpgettext: {
+        msgctxt: 1,
+        msgid: 2
+    }
 }
 ```
-Each keyword (key) requires array of argument number(s) (value). When multiple argument numbers are specified, expressions using this keyword are treaded as single-plural.
+Each keyword (key) requires an object with argument positions. The `msgid` position is required. `msgid_plural` and `msgctxt` are optional.
+For example `gettext: {msgid: 0}` indicates that the Handlebars expression looks like `{{gettext "string"}}`.
 
 #### .parse(template)
 Parses the `template` string for Swig expressions using the keywordspec.

--- a/index.js
+++ b/index.js
@@ -71,7 +71,6 @@ function Parser (customKeywordSpec) {
         throw 'Invalid keyword spec';
     }
 
-    // maintain backwards compatibility with `_: [0]` format
     Object.keys(keywordSpec).forEach(function (keyword) {
         var positions = keywordSpec[keyword];
 

--- a/index.js
+++ b/index.js
@@ -37,16 +37,60 @@ var groupParams = function (result, part) {
  */
 function Parser (customKeywordSpec) {
     var keywordSpec = customKeywordSpec || {
-        _: [0],
-        gettext: [0],
-        ngettext: [0, 1]
+        _: {
+            msgid: 0
+        },
+        gettext: {
+            msgid: 0
+        },
+        dgettext: {
+            msgid: 1
+        },
+        dcgettext: {
+            msgid: 1
+        },
+        ngettext: {
+            msgid: 0,
+            msgid_plural: 1
+        },
+        dngettext: {
+            msgid: 1,
+            msgid_plural: 2
+        },
+        pgettext: {
+            msgctxt: 0,
+            msgid: 1
+        },
+        dpgettext: {
+            msgctxt: 1,
+            msgid: 2
+        }
     };
-    var openings = ['<%', '{\\*', '{{'];
-    var closures = ['%>', '\\*}', '}}'];
 
     if (typeof keywordSpec !== 'object') {
         throw 'Invalid keyword spec';
     }
+
+    // maintain backwards compatibility with `_: [0]` format
+    Object.keys(keywordSpec).forEach(function (keyword) {
+        var positions = keywordSpec[keyword];
+
+        if ('msgid' in positions) {
+            return;
+        } else if (Array.isArray(positions) && positions.length > 0) {
+            // maintain backwards compatibility with `_: [0]` format
+            var order = ['msgid', 'msgid_plural'];
+
+            keywordSpec[keyword] = positions.slice(0).reduce(function (result, pos, idx) {
+                result[order[idx]] = pos;
+
+                return result;
+            }, {});
+        }
+    });
+
+    var openings = ['<%', '{\\*', '{{'];
+    var closures = ['%>', '\\*}', '}}'];
 
     this.keywordSpec = keywordSpec;
     this.expressionPattern = new RegExp([
@@ -77,13 +121,13 @@ Parser.prototype.parse = function (template) {
 
         params = match[2].split(',').reduce(groupParams, []).map(trim).map(trimQuotes);
 
-        msgid = params[this.keywordSpec[keyword][0]];
+        msgid = params[this.keywordSpec[keyword].msgid];
 
         result[msgid] = result[msgid] || { line: [] };
         result[msgid].line.push(template.substr(0, match.index).split(newline).length);
 
-        if (this.keywordSpec[keyword].length > 1) {
-            result[msgid].plural = result[msgid].plural || params[this.keywordSpec[keyword][1]];
+        if (this.keywordSpec[keyword].msgid_plural !== undefined) {
+            result[msgid].plural = result[msgid].plural || params[this.keywordSpec[keyword].msgid_plural];
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/pekala/gettext-ejs",
   "devDependencies": {
-    "ava": "^0.10.0",
-    "eslint": "^1.10.3"
+    "ava": "0.16.0",
+    "eslint": "3.7.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/pekala/gettext-ejs",
   "devDependencies": {
-    "ava": "0.16.0",
-    "eslint": "3.7.1"
+    "ava": "^0.21.0",
+    "eslint": "^3.19.0"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -3,7 +3,7 @@ import fs from 'fs';
 import test from 'ava';
 
 test('default', t => {
-    t.ok((new Parser()).keywordSpec.gettext.length > 0,
+    t.truthy((new Parser()).keywordSpec.gettext.length > 0,
         'should have default keyword spec when none is passed');
 });
 
@@ -13,9 +13,9 @@ test.cb('singluar', t => {
 
         var result = (new Parser()).parse(data);
         t.is(typeof result, 'object');
-        t.ok('inside block' in result);
-        t.ok('inside block inverse' in result);
-        t.ok('word \\"escaped, word\\", with comma' in result);
+        t.truthy('inside block' in result);
+        t.truthy('inside block inverse' in result);
+        t.truthy('word \\"escaped, word\\", with comma' in result);
         t.is(Object.keys(result).length, 15);
         t.is(result['Image description'].line.length, 2);
         t.end();

--- a/test/test.js
+++ b/test/test.js
@@ -5,8 +5,36 @@ import test from 'ava';
 test('default', t => {
     t.truthy('msgid' in (new Parser()).keywordSpec.gettext,
         'should have default keyword spec when none is passed');
-    t.truthy('msgid_plural' in (new Parser({gettext: [0, 1]})).keywordSpec.gettext,
-        'should support old keyword spec format');
+});
+
+test('keywords', t => {
+    const parser = new Parser({
+        _: {
+            msgid: 0
+        },
+        ngettext: {
+            msgid: 1,
+            msgid_plural: 2
+        }
+    });
+
+    t.is(parser.keywordSpec._.msgid, 0,
+        'should recognize keyword spec');
+    t.is(parser.keywordSpec.ngettext.msgid, 1,
+        'should recognize msgid position');
+    t.is(parser.keywordSpec.ngettext.msgid_plural, 2,
+        'should recognize msgid_plural position');
+});
+
+test('old keywords', t => {
+    const parser = new Parser({_: [0], ngettext: [1, 2]});
+
+    t.is(parser.keywordSpec._.msgid, 0,
+        'should recognize keyword spec');
+    t.is(parser.keywordSpec.ngettext.msgid, 1,
+        'should recognize msgid position');
+    t.is(parser.keywordSpec.ngettext.msgid_plural, 2,
+        'should recognize msgid_plural position');
 });
 
 test.cb('singluar', t => {

--- a/test/test.js
+++ b/test/test.js
@@ -3,8 +3,10 @@ import fs from 'fs';
 import test from 'ava';
 
 test('default', t => {
-    t.truthy((new Parser()).keywordSpec.gettext.length > 0,
+    t.truthy('msgid' in (new Parser()).keywordSpec.gettext,
         'should have default keyword spec when none is passed');
+    t.truthy('msgid_plural' in (new Parser({gettext: [0, 1]})).keywordSpec.gettext,
+        'should support old keyword spec format');
 });
 
 test.cb('singluar', t => {


### PR DESCRIPTION
This is a necessary step to offer support for gettext contexts. The new keyword spec (see README) contains the positions of `msgid`, `msgid_plural` and `msgctxt`. This allows [gmarty/xgettext](https://github.com/gmarty/xgettext) to send full xgettext keyword specs (e.g. `gettext:1c,2,3`).

Old format is still supported. This PR shouldn't break anything.
